### PR TITLE
Organize TVBox sources and add validation tooling

### DIFF
--- a/.github/prompts/update-tvbox-urls.prompt.md
+++ b/.github/prompts/update-tvbox-urls.prompt.md
@@ -1,0 +1,43 @@
+---
+description: "Update non-live tvbox-lines urls from the 空壳 interface list"
+name: "Update TVBox URLs"
+argument-hint: "Optional: source website URL or target JSON path"
+agent: "agent"
+---
+
+Please update [tvbox-lines.json](../../tvbox-lines.json) in the current workspace.
+
+Goal:
+Use the interfaces listed in the “空壳 接口（点击复制）” section on https://www.xn--sss604efuw.com/ to update all non-live entries inside the `urls` array.
+
+Requirements:
+1. Open https://www.xn--sss604efuw.com/.
+2. Find the “空壳 接口（点击复制）” section.
+3. Read or click-copy each interface in that section to get its display name and actual URL.
+4. Only update the `urls` array in [tvbox-lines.json](../../tvbox-lines.json).
+5. Any entry whose `name` contains “直播” or starts with “直播：” must be preserved exactly as-is.
+6. Replace or synchronize all non-live entries in the `urls` array with the interfaces from the webpage.
+7. Keep the existing live entries in their original relative order.
+8. Each new or updated non-live entry must use this format:
+   ```json
+   {
+       "url": "...",
+       "name": "..."
+   }
+   ```
+9. If the webpage contains duplicate interfaces, deduplicate by URL and keep the first name found.
+10. Do not modify `lives` or `rules` unless a JSON syntax error must be fixed.
+11. The final file must be valid JSON with no trailing commas.
+12. After editing, verify that [tvbox-lines.json](../../tvbox-lines.json) can be parsed as JSON.
+13. If any updated or existing URL contains `raw.githubusercontent.com`, `ghfast`, `gh-proxy`, `ghproxy`, `gitmirror`, or another GitHub proxy, run [scripts/repair-github-proxies.ps1](../../scripts/repair-github-proxies.ps1) before the final validation:
+    - Use PowerShell from the workspace root.
+    - Run `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force; ./scripts/repair-github-proxies.ps1 -Path ./tvbox-lines.json -TimeoutSeconds 10 -Apply`.
+    - This script validates GitHub raw/proxy URLs with TVBox-like network requests and replaces failed GitHub proxy URLs with the first reachable proxy candidate.
+    - Do not use this script to remove non-GitHub entries or preserved live entries.
+14. Run [scripts/validate-tvbox-links.ps1](../../scripts/validate-tvbox-links.ps1) to validate the updated links with TVBox-like network requests:
+    - Use PowerShell from the workspace root.
+    - Run `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force; ./scripts/validate-tvbox-links.ps1 -Path ./tvbox-lines.json -TimeoutSeconds 10`.
+    - Treat `Ok=True` as reachable at the TVBox request layer.
+    - Report any `Ok=False` entries, but do not remove preserved live entries solely because they fail validation.
+
+Modify the file directly. Do not only provide instructions.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Generated validation reports
+validate-results/

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+    "servers": {
+        "github": {
+            "type": "http",
+            "url": "https://api.githubcopilot.com/mcp/"
+        }
+    }
+}

--- a/scripts/repair-github-proxies.ps1
+++ b/scripts/repair-github-proxies.ps1
@@ -1,0 +1,276 @@
+<#
+.SYNOPSIS
+Validates and repairs GitHub raw proxy URLs in tvbox-lines.json.
+
+.DESCRIPTION
+This script scans urls and lives entries for raw.githubusercontent.com links, including links wrapped
+by common GitHub proxy prefixes. For each GitHub raw link, it simulates the TVBox/OkHttp request layer.
+
+Behavior:
+- If the current URL is reachable, it is kept.
+- If the current URL is not reachable, candidate GitHub proxy prefixes are tested.
+- The first reachable candidate replaces the failed URL when -Apply is provided.
+- Without -Apply, the script only reports planned replacements.
+
+This script intentionally validates only network reachability. It does not parse TVBox JSON, M3U, or
+image-disguised payloads.
+
+.PARAMETER Path
+Path to tvbox-lines.json.
+
+.PARAMETER TimeoutSeconds
+Request timeout per URL.
+
+.PARAMETER Apply
+Apply replacements to the JSON file. If omitted, the script runs in dry-run mode.
+
+.PARAMETER CandidatePrefixes
+GitHub proxy prefixes to try. Each prefix must accept the form: <prefix>https://raw.githubusercontent.com/...
+
+.PARAMETER AsJson
+Print result objects as JSON instead of a table.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Path = (Join-Path $PSScriptRoot '..\tvbox-lines.json'),
+
+    [Parameter()]
+    [ValidateRange(1, 120)]
+    [int]$TimeoutSeconds = 10,
+
+    [Parameter()]
+    [switch]$Apply,
+
+    [Parameter()]
+    [string[]]$CandidatePrefixes = @(
+        'https://gh-proxy.com/',
+        'https://gh.ddlc.top/',
+        'https://gh.llkk.cc/',
+        'https://ghproxy.net/',
+        'https://gh-proxy.net/',
+        'https://ghfast.top/',
+        'https://ghfast.net/',
+        'https://ghproxy.cc/',
+        'https://hub.gitmirror.com/',
+        'https://gh-proxy.ygxz.in/'
+    ),
+
+    [Parameter()]
+    [switch]$AsJson
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+
+function ConvertTo-IdnUrl {
+    param([Parameter(Mandatory)][string]$Url)
+
+    try {
+        $uri = [System.Uri]$Url
+        if ($uri.Host -match '[^\x00-\x7F]') {
+            $idn = [System.Globalization.IdnMapping]::new()
+            $builder = [System.UriBuilder]::new($uri)
+            $builder.Host = $idn.GetAscii($uri.Host)
+            return $builder.Uri.AbsoluteUri
+        }
+    }
+    catch {
+        # Let the network request surface the original URL failure.
+    }
+
+    return $Url
+}
+
+function Invoke-TvBoxLikeFetch {
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][int]$TimeoutMilliseconds
+    )
+
+    $actualUrl = ConvertTo-IdnUrl -Url $Url
+
+    try {
+        $request = [System.Net.HttpWebRequest]::Create($actualUrl)
+        $request.Method = 'GET'
+        $request.UserAgent = 'okhttp/4.12.0'
+        $request.Accept = '*/*'
+        $request.AllowAutoRedirect = $true
+        $request.MaximumAutomaticRedirections = 5
+        $request.Timeout = $TimeoutMilliseconds
+        $request.ReadWriteTimeout = $TimeoutMilliseconds
+        $request.KeepAlive = $true
+        $request.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
+
+        $response = [System.Net.HttpWebResponse]$request.GetResponse()
+        try {
+            $stream = $response.GetResponseStream()
+            $buffer = [byte[]]::new(8192)
+            $bytes = 0L
+            while (($read = $stream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+                $bytes += $read
+            }
+
+            return [pscustomobject]@{
+                Ok          = ([int]$response.StatusCode -ge 200 -and [int]$response.StatusCode -lt 400 -and $bytes -gt 0)
+                Status      = [int]$response.StatusCode
+                Bytes       = $bytes
+                ContentType = $response.ContentType
+                FinalUrl    = $response.ResponseUri.AbsoluteUri
+                Error       = ''
+            }
+        }
+        finally {
+            $response.Close()
+        }
+    }
+    catch [System.Net.WebException] {
+        $status = $null
+        $contentType = ''
+        $finalUrl = $actualUrl
+
+        if ($_.Exception.Response) {
+            $errorResponse = [System.Net.HttpWebResponse]$_.Exception.Response
+            $status = [int]$errorResponse.StatusCode
+            $contentType = $errorResponse.ContentType
+            $finalUrl = $errorResponse.ResponseUri.AbsoluteUri
+            $errorResponse.Close()
+        }
+
+        return [pscustomobject]@{
+            Ok          = $false
+            Status      = $status
+            Bytes       = 0L
+            ContentType = $contentType
+            FinalUrl    = $finalUrl
+            Error       = $_.Exception.Message
+        }
+    }
+    catch {
+        return [pscustomobject]@{
+            Ok          = $false
+            Status      = $null
+            Bytes       = 0L
+            ContentType = ''
+            FinalUrl    = $actualUrl
+            Error       = $_.Exception.Message
+        }
+    }
+}
+
+function Get-RawGitHubUrl {
+    param([Parameter(Mandatory)][string]$Url)
+
+    if ($Url -match '(https://raw\.githubusercontent\.com/.+)$') {
+        return $Matches[1]
+    }
+
+    return $null
+}
+
+function Join-ProxyUrl {
+    param(
+        [Parameter(Mandatory)][string]$Prefix,
+        [Parameter(Mandatory)][string]$RawUrl
+    )
+
+    return $Prefix.TrimEnd('/') + '/' + $RawUrl
+}
+
+$resolvedPath = Resolve-Path -LiteralPath $Path
+$fileText = Get-Content -Raw -Encoding UTF8 -LiteralPath $resolvedPath
+$config = $fileText | ConvertFrom-Json
+
+$entries = @()
+if ($config.urls) {
+    foreach ($item in $config.urls) {
+        $entries += [pscustomobject]@{ Source = 'urls'; Name = [string]$item.name; Url = [string]$item.url }
+    }
+}
+if ($config.lives) {
+    foreach ($item in $config.lives) {
+        $entries += [pscustomobject]@{ Source = 'lives'; Name = [string]$item.name; Url = [string]$item.url }
+    }
+}
+
+$timeoutMilliseconds = $TimeoutSeconds * 1000
+$results = @()
+$replacementByUrl = @{}
+$index = 0
+
+foreach ($entry in $entries) {
+    $index++
+    $rawUrl = Get-RawGitHubUrl -Url $entry.Url
+    if (-not $rawUrl) {
+        continue
+    }
+
+    $current = Invoke-TvBoxLikeFetch -Url $entry.Url -TimeoutMilliseconds $timeoutMilliseconds
+    $selectedUrl = $entry.Url
+    $selected = $current
+    $action = if ($current.Ok) { 'KeepCurrent' } else { 'NoReplacementFound' }
+
+    if (-not $current.Ok) {
+        foreach ($prefix in $CandidatePrefixes) {
+            $candidateUrl = Join-ProxyUrl -Prefix $prefix -RawUrl $rawUrl
+            if ($candidateUrl -eq $entry.Url) {
+                continue
+            }
+
+            $candidate = Invoke-TvBoxLikeFetch -Url $candidateUrl -TimeoutMilliseconds $timeoutMilliseconds
+            if ($candidate.Ok) {
+                $selectedUrl = $candidateUrl
+                $selected = $candidate
+                $action = if ($Apply) { 'Replace' } else { 'WouldReplace' }
+                $replacementByUrl[$entry.Url] = $selectedUrl
+                break
+            }
+        }
+    }
+
+    $results += [pscustomobject]@{
+        No             = $index
+        Source         = $entry.Source
+        Name           = $entry.Name
+        CurrentOk      = $current.Ok
+        CurrentStatus  = $current.Status
+        Action         = $action
+        SelectedOk     = $selected.Ok
+        SelectedStatus = $selected.Status
+        SelectedBytes  = $selected.Bytes
+        CurrentUrl     = $entry.Url
+        SelectedUrl    = $selectedUrl
+        Error          = if ($current.Ok) { '' } else { $current.Error }
+    }
+}
+
+if ($Apply -and $replacementByUrl.Count -gt 0) {
+    foreach ($oldUrl in $replacementByUrl.Keys) {
+        $newUrl = [string]$replacementByUrl[$oldUrl]
+        $fileText = $fileText.Replace($oldUrl, $newUrl)
+    }
+
+    Set-Content -LiteralPath $resolvedPath -Encoding UTF8 -NoNewline -Value $fileText
+}
+
+if ($AsJson) {
+    $results | ConvertTo-Json -Depth 5
+}
+else {
+    $results | Format-Table No, Source, Name, CurrentOk, CurrentStatus, Action, SelectedStatus, SelectedBytes -AutoSize -Wrap
+    ''
+    'Summary:'
+    "GitHub raw/proxy links checked: $($results.Count)"
+    "Replacements: $($replacementByUrl.Count)"
+    if (-not $Apply -and $replacementByUrl.Count -gt 0) {
+        'Dry run only. Re-run with -Apply to write replacements.'
+    }
+
+    $unfixed = @($results | Where-Object { -not $_.SelectedOk })
+    if ($unfixed.Count -gt 0) {
+        ''
+        'Unfixed GitHub links:'
+        $unfixed | Select-Object No, Source, Name, CurrentStatus, Error, CurrentUrl | Format-List
+    }
+}

--- a/scripts/validate-tvbox-links.ps1
+++ b/scripts/validate-tvbox-links.ps1
@@ -1,0 +1,315 @@
+<#
+.SYNOPSIS
+Validates TVBox-related links by simulating the network request style used by TVBox/OkHttp.
+
+.DESCRIPTION
+This script reads tvbox-lines.json, requests every entry in urls and lives, and reports whether
+the URL is reachable at the network layer. It intentionally does not parse TVBox JSON, image-disguised
+interfaces, M3U playlists, or other response payloads.
+
+The request simulation uses:
+- GET requests
+- OkHttp-like User-Agent
+- Accept: */*
+- automatic redirects
+- gzip/deflate decompression
+- IDN/punycode conversion for non-ASCII host names
+
+.PARAMETER Path
+Path to tvbox-lines.json.
+
+.PARAMETER TimeoutSeconds
+Request timeout per URL.
+
+.PARAMETER FailOnUnavailable
+Exit with code 1 when one or more URLs cannot be fetched successfully.
+
+.PARAMETER AsJson
+Print the validation result objects as JSON instead of a table.
+
+.PARAMETER ResultsDirectory
+Directory where the HTML validation report will be saved.
+
+.PARAMETER NoHtml
+Skip writing the HTML validation report.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Path = (Join-Path $PSScriptRoot '..\tvbox-lines.json'),
+
+    [Parameter()]
+    [ValidateRange(1, 120)]
+    [int]$TimeoutSeconds = 10,
+
+    [Parameter()]
+    [switch]$FailOnUnavailable,
+
+    [Parameter()]
+    [switch]$AsJson,
+
+    [Parameter()]
+    [string]$ResultsDirectory = (Join-Path $PSScriptRoot '..\validate-results'),
+
+    [Parameter()]
+    [switch]$NoHtml
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+
+function ConvertTo-IdnUrl {
+    param([Parameter(Mandatory)][string]$Url)
+
+    try {
+        $uri = [System.Uri]$Url
+        if ($uri.Host -match '[^\x00-\x7F]') {
+            $idn = [System.Globalization.IdnMapping]::new()
+            $builder = [System.UriBuilder]::new($uri)
+            $builder.Host = $idn.GetAscii($uri.Host)
+            return $builder.Uri.AbsoluteUri
+        }
+    }
+    catch {
+        # Return the original URL and let the request surface the failure.
+    }
+
+    return $Url
+}
+
+function Invoke-TvBoxLikeFetch {
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][int]$TimeoutMilliseconds
+    )
+
+    $actualUrl = ConvertTo-IdnUrl -Url $Url
+
+    try {
+        $request = [System.Net.HttpWebRequest]::Create($actualUrl)
+        $request.Method = 'GET'
+        $request.UserAgent = 'okhttp/4.12.0'
+        $request.Accept = '*/*'
+        $request.AllowAutoRedirect = $true
+        $request.MaximumAutomaticRedirections = 5
+        $request.Timeout = $TimeoutMilliseconds
+        $request.ReadWriteTimeout = $TimeoutMilliseconds
+        $request.KeepAlive = $true
+        $request.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
+
+        $response = [System.Net.HttpWebResponse]$request.GetResponse()
+        try {
+            $stream = $response.GetResponseStream()
+            $buffer = [byte[]]::new(8192)
+            $bytes = 0L
+
+            while (($read = $stream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+                $bytes += $read
+            }
+
+            return [pscustomobject]@{
+                Ok          = ([int]$response.StatusCode -ge 200 -and [int]$response.StatusCode -lt 400)
+                Status      = [int]$response.StatusCode
+                Bytes       = $bytes
+                ContentType = $response.ContentType
+                FinalUrl    = $response.ResponseUri.AbsoluteUri
+                Error       = ''
+            }
+        }
+        finally {
+            $response.Close()
+        }
+    }
+    catch [System.Net.WebException] {
+        $status = $null
+        $contentType = ''
+        $finalUrl = $actualUrl
+
+        if ($_.Exception.Response) {
+            $errorResponse = [System.Net.HttpWebResponse]$_.Exception.Response
+            $status = [int]$errorResponse.StatusCode
+            $contentType = $errorResponse.ContentType
+            $finalUrl = $errorResponse.ResponseUri.AbsoluteUri
+            $errorResponse.Close()
+        }
+
+        return [pscustomobject]@{
+            Ok          = $false
+            Status      = $status
+            Bytes       = 0L
+            ContentType = $contentType
+            FinalUrl    = $finalUrl
+            Error       = $_.Exception.Message
+        }
+    }
+    catch {
+        return [pscustomobject]@{
+            Ok          = $false
+            Status      = $null
+            Bytes       = 0L
+            ContentType = ''
+            FinalUrl    = $actualUrl
+            Error       = $_.Exception.Message
+        }
+    }
+}
+
+function New-HtmlReport {
+        param(
+                [Parameter(Mandatory)][object[]]$Results,
+                [Parameter(Mandatory)][string]$ConfigPath,
+                [Parameter(Mandatory)][string]$OutputDirectory
+        )
+
+        if (-not (Test-Path -LiteralPath $OutputDirectory)) {
+                New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+        }
+
+        $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $reportPath = Join-Path $OutputDirectory "validate-tvbox-links-$timestamp.html"
+        $generatedAt = Get-Date -Format 'yyyy-MM-dd HH:mm:ss zzz'
+        $okCount = @($Results | Where-Object { $_.Ok }).Count
+        $failedCount = @($Results | Where-Object { -not $_.Ok }).Count
+
+        $style = @'
+body { font-family: "Segoe UI", Arial, sans-serif; margin: 24px; color: #1f2328; }
+h1 { margin-bottom: 4px; }
+.meta { color: #57606a; margin-bottom: 16px; }
+.summary { display: flex; gap: 12px; margin: 16px 0 24px; }
+.card { border: 1px solid #d0d7de; border-radius: 8px; padding: 12px 16px; min-width: 120px; background: #f6f8fa; }
+.card strong { display: block; font-size: 24px; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #d0d7de; padding: 8px; vertical-align: top; }
+th { background: #f6f8fa; text-align: left; }
+tr.ok { background: #dafbe1; }
+tr.failed { background: #ffebe9; }
+td.url { word-break: break-all; }
+'@
+
+        $rows = foreach ($result in $Results) {
+                $class = if ($result.Ok) { 'ok' } else { 'failed' }
+                $status = if ($null -eq $result.Status) { '' } else { [System.Net.WebUtility]::HtmlEncode([string]$result.Status) }
+                @"
+<tr class="$class">
+    <td>$([System.Net.WebUtility]::HtmlEncode([string]$result.No))</td>
+    <td>$([System.Net.WebUtility]::HtmlEncode($result.Source))</td>
+    <td>$([System.Net.WebUtility]::HtmlEncode($result.Name))</td>
+    <td>$([System.Net.WebUtility]::HtmlEncode([string]$result.Ok))</td>
+    <td>$status</td>
+    <td>$([System.Net.WebUtility]::HtmlEncode([string]$result.Bytes))</td>
+    <td>$([System.Net.WebUtility]::HtmlEncode($result.ContentType))</td>
+    <td class="url">$([System.Net.WebUtility]::HtmlEncode($result.Url))</td>
+    <td class="url">$([System.Net.WebUtility]::HtmlEncode($result.FinalUrl))</td>
+    <td>$([System.Net.WebUtility]::HtmlEncode($result.Error))</td>
+</tr>
+"@
+        }
+
+        $html = @"
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>TVBox Link Validation Report</title>
+    <style>$style</style>
+</head>
+<body>
+    <h1>TVBox Link Validation Report</h1>
+    <div class="meta">Generated: $([System.Net.WebUtility]::HtmlEncode($generatedAt))<br>Config: $([System.Net.WebUtility]::HtmlEncode($ConfigPath))</div>
+    <div class="summary">
+        <div class="card"><span>Total</span><strong>$($Results.Count)</strong></div>
+        <div class="card"><span>Ok</span><strong>$okCount</strong></div>
+        <div class="card"><span>Failed</span><strong>$failedCount</strong></div>
+    </div>
+    <table>
+        <thead>
+            <tr>
+                <th>No</th><th>Source</th><th>Name</th><th>Ok</th><th>Status</th><th>Bytes</th><th>Content Type</th><th>URL</th><th>Final URL</th><th>Error</th>
+            </tr>
+        </thead>
+        <tbody>
+$($rows -join "`n")
+        </tbody>
+    </table>
+</body>
+</html>
+"@
+
+        Set-Content -LiteralPath $reportPath -Encoding UTF8 -NoNewline -Value $html
+        return $reportPath
+}
+
+$resolvedPath = Resolve-Path -LiteralPath $Path
+$config = Get-Content -Raw -Encoding UTF8 -LiteralPath $resolvedPath | ConvertFrom-Json
+
+$entries = @()
+if ($config.urls) {
+    foreach ($item in $config.urls) {
+        $entries += [pscustomobject]@{
+            Source = 'urls'
+            Name   = [string]$item.name
+            Url    = [string]$item.url
+        }
+    }
+}
+if ($config.lives) {
+    foreach ($item in $config.lives) {
+        $entries += [pscustomobject]@{
+            Source = 'lives'
+            Name   = [string]$item.name
+            Url    = [string]$item.url
+        }
+    }
+}
+
+$timeoutMilliseconds = $TimeoutSeconds * 1000
+$index = 0
+$results = foreach ($entry in $entries) {
+    $index++
+    $result = Invoke-TvBoxLikeFetch -Url $entry.Url -TimeoutMilliseconds $timeoutMilliseconds
+
+    [pscustomobject]@{
+        No          = $index
+        Source      = $entry.Source
+        Name        = $entry.Name
+        Ok          = $result.Ok
+        Status      = $result.Status
+        Bytes       = $result.Bytes
+        ContentType = $result.ContentType
+        Url         = $entry.Url
+        FinalUrl    = $result.FinalUrl
+        Error       = $result.Error
+    }
+}
+
+$reportPath = $null
+if (-not $NoHtml) {
+    $reportPath = New-HtmlReport -Results @($results) -ConfigPath $resolvedPath.Path -OutputDirectory $ResultsDirectory
+}
+
+if ($AsJson) {
+    $results | ConvertTo-Json -Depth 5
+}
+else {
+    $results | Format-Table No, Source, Name, Ok, Status, Bytes, ContentType -AutoSize -Wrap
+    ''
+    'Summary:'
+    $results | Group-Object Ok | Sort-Object Name | ForEach-Object { "Ok=$($_.Name): $($_.Count)" }
+
+    $failed = @($results | Where-Object { -not $_.Ok })
+    if ($failed.Count -gt 0) {
+        ''
+        'Failed:'
+        $failed | Select-Object No, Source, Name, Status, Error, Url | Format-List
+    }
+
+    if ($reportPath) {
+        ''
+        "HTML report: $reportPath"
+    }
+}
+
+if ($FailOnUnavailable -and @($results | Where-Object { -not $_.Ok }).Count -gt 0) {
+    exit 1
+}

--- a/tvbox-lines.json
+++ b/tvbox-lines.json
@@ -8,58 +8,50 @@
             "url": "https://tv.iill.top/m3u/Adult",
             "name": "直播：YanG-1989-成人"
         },
-    ],
-    "urls": [
         {
-            "url": "http://www.饭太硬.net/tv",
-            "name": "🍚饭太硬🍚"
-        },
-        {
-            "url": "http://ok321.top/tv",
-            "name": "Ok吊炸天"
-        },
-        {
-            "url": "http://肥猫.com/",
-            "name": "肥猫"
-        },
-        {
-            "url": "http://192.168.1.110:35455/tv.m3u",
-            "name": "直播：本地tv"
-        },
-        {
-            "url": "http://192.168.1.110:35455/bililive.m3u",
-            "name": "直播：本地bililive"
-        },
-        {
-            "url": "http://192.168.1.110:35455/yylunbo.m3u",
-            "name": "直播：本地YY轮播"
-        },
-        {
-            "url": "https://ghfast.top/https://raw.githubusercontent.com/fanmingming/live/refs/heads/main/tv/m3u/ipv6.m3u",
+            "url": "https://gh-proxy.com/https://raw.githubusercontent.com/fanmingming/live/refs/heads/main/tv/m3u/ipv6.m3u",
             "name": "直播：范明明ipv6"
         },
         {
-            "url": "https://ghfast.top/https://raw.githubusercontent.com/fanmingming/live/refs/heads/main/tv/m3u/itv.m3u",
+            "url": "https://gh-proxy.com/https://raw.githubusercontent.com/fanmingming/live/refs/heads/main/tv/m3u/itv.m3u",
             "name": "直播：范明明itv"
         },
         {
-            "url": "https://ghfast.top/https://raw.githubusercontent.com/yuanzl77/IPTV/refs/heads/main/live.m3u",
+            "url": "https://gh-proxy.com/https://raw.githubusercontent.com/yuanzl77/IPTV/refs/heads/main/live.m3u",
             "name": "直播：yuanzl77"
         },
         {
-            "url": "https://ghfast.top/https://raw.githubusercontent.com/YanG-1989/m3u/main/Gather.m3u",
+            "url": "https://gh-proxy.com/https://raw.githubusercontent.com/YanG-1989/m3u/main/Gather.m3u",
             "name": "直播：YanG-1989-综合"
         },
         {
-            "url": "https://ghfast.top/https://raw.githubusercontent.com/YueChan/Live/refs/heads/main/APTV.m3u",
+            "url": "https://gh-proxy.com/https://raw.githubusercontent.com/YueChan/Live/main/IPTV.m3u",
             "name": "直播：YueChan"
         },
         {
-            "url": "https://ghfast.top/https://raw.githubusercontent.com/gaotianliuyun/gao/master/0825.json",
-            "name": "PG one"
+            "url": "http://175.178.251.183:6689/live.m3u",
+            "name": "直播：yuanzl77-备1"
         },
         {
-            "url": "https://mpanso.me/DEMO.json",
+            "url": "https://tv.iill.top/m3u/MyTV",
+            "name": "直播：YanG-1989-MyTV"
+        }
+    ],
+    "urls": [
+        {
+            "url": "http://www.饭太硬.cc/tv",
+            "name": "饭太硬"
+        },
+        {
+            "url": "http://fty.xxooo.cf/tv",
+            "name": "饭太硬备用"
+        },
+        {
+            "url": "https://raw.atomgit.com/xxxooo/fan/blobs/cef5f441c422cffe4852e0fc8b102f9be6d2bb2b/in.bmp",
+            "name": "饭太硬备用"
+        },
+        {
+            "url": "http://mitvbox.xyz/%E5%B0%8F%E7%B1%B3/DEMO.json",
             "name": "小米"
         },
         {
@@ -67,48 +59,16 @@
             "name": "王二小"
         },
         {
-            "url": "https://100km.top/0",
-            "name": "骚零"
+            "url": "http://ok213.top/tv",
+            "name": "jack老师"
         },
         {
-            "url": "http://bp.tvbox.cam/",
-            "name": "小白"
+            "url": "http://cdn.qiaoji8.com/tvbox.json",
+            "name": "巧技"
         },
         {
-            "url": "https://gitee.com/xxoooo/fan/raw/master/in.bmp",
-            "name": "饭太硬-江苏"
-        },
-        {
-            "url": "http://175.178.251.183:6689/live.m3u",
-            "name": "直播：yuanzl77-备1"
-        },
-        {
-            "url": "https://tv.iill.top/m3u/Live",
-            "name": "直播：YanG-1989-直播间"
-        },
-        {
-            "url": "https://tv.iill.top/m3u/MyTV",
-            "name": "直播：YanG-1989-MyTV"
-        },
-        {
-            "url": "http://饭太硬.com/tv",
-            "name": "饭太硬-备1"
-        },
-        {
-            "url": "http://饭太硬.xyz/tv",
-            "name": "饭太硬-备2"
-        },
-        {
-            "url": "http://fty.xxooo.cf/tv",
-            "name": "饭太硬-备3"
-        },
-        {
-            "url": "http://miqk.cc/小米/DEMO.json",
-            "name": "小米-备1"
-        },
-        {
-            "url": "https://ghfast.top/https://raw.githubusercontent.com/fanmingming/live/main/radio/m3u/index.m3u",
-            "name": "广播：范明明"
+            "url": "https://gh-proxy.com/https://raw.githubusercontent.com/yoursmile66/TVBox/refs/heads/main/XC.json",
+            "name": "南风"
         }
     ],
     "rules": [


### PR DESCRIPTION
## Summary
- Reorganize `tvbox-lines.json` for OK影视 by separating 点播 interfaces into `urls` and live sources into `lives`
- Replace failing GitHub proxy URLs with verified `gh-proxy.com` links and update the YueChan playlist path
- Add reusable PowerShell tooling for TVBox-like link validation and GitHub proxy repair
- Add a reusable Copilot prompt for updating TVBox URLs
- Ignore generated `validate-results/` HTML reports
- Configure the official GitHub MCP server for the workspace

## Validation
- Parsed `tvbox-lines.json` successfully as JSON
- Ran GitHub proxy repair dry-run successfully: all 6 GitHub raw/proxy links kept current
- Ran TVBox-like validator; generated HTML validation reports locally under ignored `validate-results/`
